### PR TITLE
Add new task

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ directions.navigate({
   to: { // either pass in a single object or an Array (see the TypeScript example below)
     address: "Hof der Kolommen 34, Amersfoort, Netherlands"
   }
-  // for iOS-specific options, see the TypeScript example below.
+  // for platform-specific options, see the TypeScript example below.
 }).then(
   function() {
     console.log("Maps app launched.");
@@ -113,6 +113,9 @@ directions.navigate({
   ios: {
     preferGoogleMaps: true, // If the Google Maps app is installed, use that one instead of Apple Maps, because it supports waypoints. Default true.
     allowGoogleMapsWeb: true // If waypoints are passed in and Google Maps is not installed, you can either open Apple Maps and the first waypoint is used as the to-address (the rest is ignored), or you can open Google Maps on web so all waypoints are shown (set this property to true). Default false.
+  },
+  android: {
+    newTask: true // Start as new task. This means it will start a new history stack instead of using the current app. Default true.
   }
 }).then(() => {
     console.log("Maps app launched.");

--- a/src/directions.android.ts
+++ b/src/directions.android.ts
@@ -9,8 +9,8 @@ export class Directions extends DirectionsCommon implements DirectionsApi {
   private isPackageInstalled(): boolean {
     try {
       let intent = new android.content.Intent(
-          android.content.Intent.ACTION_VIEW,
-          android.net.Uri.parse("http://maps.google.com/maps"));
+        android.content.Intent.ACTION_VIEW,
+        android.net.Uri.parse("http://maps.google.com/maps"));
 
       let pm = com.tns.NativeScriptApplication.getInstance().getPackageManager();
       return intent.resolveActivity(pm) != null;
@@ -35,8 +35,12 @@ export class Directions extends DirectionsCommon implements DirectionsApi {
           utils.openUrl("http://maps.google.com/maps" + fromToQs);
         } else {
           const intent = new android.content.Intent(
-              android.content.Intent.ACTION_VIEW,
-              android.net.Uri.parse("http://maps.google.com/maps" + fromToQs));
+            android.content.Intent.ACTION_VIEW,
+            android.net.Uri.parse("http://maps.google.com/maps" + fromToQs));
+
+          if (!options.android || options.android.newTask !== false) {
+            intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK);
+          }
 
           (application.android.foregroundActivity || application.android.startActivity).startActivityForResult(intent, 0);
         }

--- a/src/directions.common.ts
+++ b/src/directions.common.ts
@@ -45,6 +45,15 @@ export interface NavigateToOptions {
     allowGoogleMapsWeb?: boolean;
   };
 
+  android?: {
+    /**
+     * Start as new task. This means it will start a new history stack instead of using the current app.
+     *
+     * Default true.
+     */
+    newTask?: boolean;
+  };
+
   type?: NavigateToOptionsType;
 }
 
@@ -56,8 +65,8 @@ export interface DirectionsApi {
 export class DirectionsCommon {
   static getFromToQuerystring(options: NavigateToOptions): string {
     let dest = undefined,
-        source = null,
-        qs = "?saddr=";
+      source = null,
+      qs = "?saddr=";
 
     if (options.from) {
       if (options.from.address) {


### PR DESCRIPTION
This feature adds support for starting a new history stack. This means that the Google Maps app is started as it's own app, instead of the history stack of your own app.

This fixes #29